### PR TITLE
Change DB name

### DIFF
--- a/NftFaucet/Program.cs
+++ b/NftFaucet/Program.cs
@@ -39,7 +39,7 @@ builder.Services.AddMetaMaskBlazor();
 
 builder.Services.AddIndexedDB(dbStore =>
 {
-    dbStore.DbName = "NftFaucet";
+    dbStore.DbName = "NftFaucetV2";
     dbStore.Version = 1;
 
     dbStore.Stores.Add(new StoreSchema


### PR DESCRIPTION
Change DB name, there seems to be some issue with migrating pre-existing DB to version 2.
Change name so we start with a new one instead. Will try to get migration working in the future.